### PR TITLE
feat(common-frontend): Dependent rendering

### DIFF
--- a/packages/common-frontend/src/components/Descriptions/Descriptions.tsx
+++ b/packages/common-frontend/src/components/Descriptions/Descriptions.tsx
@@ -1,6 +1,6 @@
 import { ActionType } from "@ant-design/pro-table";
 import React, { Key, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
-import { Badge, Button, Result, Tabs, TabsProps, Tooltip } from "antd";
+import { Badge, Button, Form, Result, Tabs, TabsProps, Tooltip } from "antd";
 import { DeleteOutlined, StopOutlined } from "@ant-design/icons";
 import { FormattedMessage, useIntl } from "react-intl";
 import { DescriptionsRefType, FieldsEdit, TDescriptionsProps, TGetOneParams } from "./descriptionTypes";
@@ -21,7 +21,7 @@ import { debounce } from "lodash";
 import { NamePath } from "antd/lib/form/interface";
 import { FieldData } from "rc-field-form/lib/interface";
 
-const useStyles = createStyles(({css}) => {
+const useStyles = createStyles(({ css }) => {
   return {
     antDescriptionsStyles: css`
       .ant-descriptions-item-content {
@@ -62,6 +62,7 @@ const DescriptionsComponent = <Entity extends Record<string | symbol, any>,
     columns,
     params,
     onEntityChange,
+    conditionalFieldsConfig,
     ...rest
   }: TDescriptionsProps<Entity,
     CreateDto,
@@ -80,13 +81,36 @@ const DescriptionsComponent = <Entity extends Record<string | symbol, any>,
   }
   form = editable.form;
 
+  const watchedValue = conditionalFieldsConfig
+    ? Form.useWatch(conditionalFieldsConfig.field, form)
+    : undefined;
+
+  const filteredColumns = React.useMemo(() => {
+    if (!conditionalFieldsConfig) {
+      return columns;
+    }
+
+    const { field, deps } = conditionalFieldsConfig;
+    const depsList = deps[watchedValue as string];
+
+    if (!depsList?.length) {
+      return columns;
+    }
+
+    // Always include the watched field itself
+    return columns.filter(col => {
+      const idx = col.dataIndex as string;
+      return idx === field || depsList.includes(idx);
+    });
+  }, [columns, watchedValue, conditionalFieldsConfig]);
+
   const actionRefComponent = useRef<ActionType>();
   const actionRef = actionRefProp || actionRefComponent;
   const intl = useIntl();
   const [data, setData] = useState<Partial<Entity> | undefined>(entity);
   const [loading, setLoading] = useState(false);
 
-  const sections = columnsToDescriptionItemProps(columns, mainTitle);
+  const sections = columnsToDescriptionItemProps(filteredColumns, mainTitle);
 
   const columnDataIndexToSection = sections.reduce((acc, section) => {
     section.columns.forEach(column => {

--- a/packages/common-frontend/src/components/Descriptions/descriptionTypes.ts
+++ b/packages/common-frontend/src/components/Descriptions/descriptionTypes.ts
@@ -35,7 +35,15 @@ export enum FieldsEdit {
   All = 'all'
 }
 
+export interface ConditionalFieldsConfig {
+  /** Which field to watch */
+  field: string;
+  /** Map of watched-value → array of dataIndex you want to show */
+  deps: Record<string, string[]>;
+}
+
 export type TDescriptionsProps<Entity, CreateDto, UpdateDto, TPathParams = object> = {
+  conditionalFieldsConfig?: ConditionalFieldsConfig;
   mainTitle?: ProColumns<Entity>['title'] | null,
   entity?: Partial<Entity>,
   getOne?: ({}: TGetOneParams & TPathParams) => Promise<Entity | null>,

--- a/packages/common-frontend/src/components/Table/CreateEntityModal.tsx
+++ b/packages/common-frontend/src/components/Table/CreateEntityModal.tsx
@@ -1,7 +1,7 @@
 import { ProColumns } from "@ant-design/pro-components";
 import { Button, Modal } from "antd";
 import { MutableRefObject, useRef } from "react";
-import { Descriptions, DescriptionsRefType } from "../Descriptions";
+import { ConditionalFieldsConfig, Descriptions, DescriptionsRefType } from "../Descriptions";
 import { buildFieldsFromColumnsForDescriptionsDisplay } from "./tableTools";
 
 export interface CreateEntityModalProps<Entity> {
@@ -24,6 +24,8 @@ export interface CreateEntityModalProps<Entity> {
    * Receives the validated form data.
    */
   onSubmit: (data: any, descriptionsRef: MutableRefObject<DescriptionsRefType<Entity>>) => Promise<void>;
+  /** Configuration for conditional fields */
+  conditionalFieldsConfig?: ConditionalFieldsConfig
 }
 
 export function CreateEntityModal<
@@ -40,6 +42,7 @@ export function CreateEntityModal<
   idColumnName,
   onCancel,
   onSubmit,
+  conditionalFieldsConfig,
 }: CreateEntityModalProps<Entity>) {
   const descriptionsRef = useRef<DescriptionsRefType<Entity>>(null);
 
@@ -79,6 +82,7 @@ export function CreateEntityModal<
           editableKeys,
           actionRender: () => [],
         }}
+        conditionalFieldsConfig={conditionalFieldsConfig}
       />
     </Modal>
   );

--- a/packages/common-frontend/src/components/Table/Table.tsx
+++ b/packages/common-frontend/src/components/Table/Table.tsx
@@ -55,6 +55,7 @@ const Table = <Entity extends Record<string | symbol, any>,
     columnsState: managedColumnsState,
     columnsSetSelect: managedColumnsSetSelect,
     popupCreation = false,
+    conditionalFieldsConfig,
     toolBarRender,
     params,
     editPopupTitle,
@@ -120,6 +121,7 @@ const Table = <Entity extends Record<string | symbol, any>,
     createButtonSize: rest.size,
     popupCreation,
     createNewDefaultParams,
+    conditionalFieldsConfig,
   });
 
   const { exportButton, importButton, setLastQueryParams } = useImportExport<TPathParams>({

--- a/packages/common-frontend/src/components/Table/tableTypes.ts
+++ b/packages/common-frontend/src/components/Table/tableTypes.ts
@@ -6,6 +6,7 @@ import { TColumnsSet } from "./useColumnsSets";
 import { ColumnStateType } from "@ant-design/pro-table/es/typing";
 import { RowEditableConfig } from "@ant-design/pro-utils";
 import { ProColumns } from "@ant-design/pro-components";
+import { ConditionalFieldsConfig } from "../Descriptions";
 
 export type IWithId = {
   id: string | number,
@@ -96,6 +97,7 @@ interface BaseProps<Entity,
   viewOnly?: boolean;
   columnsSets?: TColumnsSet<Entity>[];
   popupCreation?: boolean;
+  conditionalFieldsConfig?: ConditionalFieldsConfig;
   columnsState?: ColumnStateType;
   columnsSetSelect?: () => React.ReactNode;
   editPopupTitle?: string;

--- a/packages/common-frontend/src/components/Table/useCreation.tsx
+++ b/packages/common-frontend/src/components/Table/useCreation.tsx
@@ -32,6 +32,7 @@ export function useCreation<Entity, CreateDto, TPathParams = {}>({
   createButtonSize,
   popupCreation,
   createNewDefaultParams,
+  conditionalFieldsConfig,
 }: {
   actionRef?: MutableRefObject<ActionType | undefined>;
   pathParams: TPathParams;
@@ -105,6 +106,7 @@ export function useCreation<Entity, CreateDto, TPathParams = {}>({
       setCreatePopupData(undefined);
     }}
     onSubmit={onCreateSubmit}
+    conditionalFieldsConfig={conditionalFieldsConfig}
   />;
 
   return {


### PR DESCRIPTION
This pull request introduces a new feature that allows for conditional display of fields in the `Descriptions` component and its related modals and tables. By providing a `conditionalFieldsConfig` prop, consumers can control which fields are shown based on the value of another field. This feature is integrated throughout the entity creation flow, making forms more dynamic and responsive to user input.

**Conditional Field Display Feature:**

* Added `ConditionalFieldsConfig` type and `conditionalFieldsConfig` prop to `Descriptions` and related components, enabling configuration of which fields to show based on another field's value. [[1]](diffhunk://#diff-dfceaf23e2411aa843577d194193dd916429b0172f6e1beb696815e35962366bR38-R46) [[2]](diffhunk://#diff-7f81a82f910cfbf28d70af663cafc382dba962644a6ed2bc0a81645421130a17R65) [[3]](diffhunk://#diff-7f81a82f910cfbf28d70af663cafc382dba962644a6ed2bc0a81645421130a17R84-R113)
* Updated `DescriptionsComponent` to filter columns according to `conditionalFieldsConfig`, using `Form.useWatch` to reactively update visible fields. [[1]](diffhunk://#diff-7f81a82f910cfbf28d70af663cafc382dba962644a6ed2bc0a81645421130a17L3-R3) [[2]](diffhunk://#diff-7f81a82f910cfbf28d70af663cafc382dba962644a6ed2bc0a81645421130a17R84-R113)

**Integration with Table and Modal Components:**

* Extended `CreateEntityModal` and `Table` components to accept and pass through the `conditionalFieldsConfig` prop, ensuring conditional field logic is respected in entity creation flows. [[1]](diffhunk://#diff-79a1f01404409bf58bcdf0a8fa1c823d766354f1ec04565683aa00e37ca9ddf6L4-R4) [[2]](diffhunk://#diff-79a1f01404409bf58bcdf0a8fa1c823d766354f1ec04565683aa00e37ca9ddf6R27-R28) [[3]](diffhunk://#diff-79a1f01404409bf58bcdf0a8fa1c823d766354f1ec04565683aa00e37ca9ddf6R45) [[4]](diffhunk://#diff-79a1f01404409bf58bcdf0a8fa1c823d766354f1ec04565683aa00e37ca9ddf6R85) [[5]](diffhunk://#diff-91178976f512017c5f4c74a026718f6467fc52470a3e74a12b95b96ef1512841R58) [[6]](diffhunk://#diff-91178976f512017c5f4c74a026718f6467fc52470a3e74a12b95b96ef1512841R124) [[7]](diffhunk://#diff-540ea1a6a5f4b16d470ce16834aa6b2926f4d7162e3be902a4ce0923c9a91cd0R9) [[8]](diffhunk://#diff-540ea1a6a5f4b16d470ce16834aa6b2926f4d7162e3be902a4ce0923c9a91cd0R100)
* Updated `useCreation` hook to accept and forward `conditionalFieldsConfig` to the modal, maintaining consistency across creation and editing experiences. [[1]](diffhunk://#diff-f55c0cf4897796a42eac23596c6bbfbb205be6f06606744352a86452ed67e8c1R35) [[2]](diffhunk://#diff-f55c0cf4897796a42eac23596c6bbfbb205be6f06606744352a86452ed67e8c1R109)